### PR TITLE
[marks] Dump lookupType9: Extension positioning

### DIFF
--- a/Lib/diffenator/marks.py
+++ b/Lib/diffenator/marks.py
@@ -54,6 +54,10 @@ class DumpMarks:
     def _get_groups(self):
         for lookup in self._lookups:
             for sub_table in lookup.SubTable:
+
+                if hasattr(sub_table, 'ExtSubTable'):
+                    sub_table = sub_table.ExtSubTable
+
                 # get mark marks
                 if sub_table.Format == 1 and sub_table.LookupType == 4:
                     base_lookup_anchors = self._get_base_anchors(


### PR DESCRIPTION
Sometimes, font generators will need to gen this lookup type.

> This is needed if the total size of the subtables exceeds the 16-bit limits of the various other offsets in the 'GPOS' table. In this specification, the subtable stored at the 32-bit offset location is termed the “extension” subtable.

https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning