### PR TITLE
Find glyph differences by comparing rendered glyphs

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,2 +1,2 @@
 from diffenator.diff import diff_fonts
-__version__ = "0.3.2"
+__version__ = "0.4.2"

--- a/Lib/diffenator/__main__.py
+++ b/Lib/diffenator/__main__.py
@@ -36,6 +36,9 @@ diffenator /path/to/font_a.ttf /path/to/font_b.ttf -md
 
 Diff kerning and ignore differences under 30 units:
 diffenator /path/to/font_a.ttf /path/to/font_b.ttf -td kerns --kerns_thresh 30
+
+Diff rendered glyphs:
+diffenator /path/to/font_a.ttf /path/to/font_b.ttf -td glyphs -rd
 """
 from argparse import RawTextHelpFormatter
 from diffenator.diff import diff_fonts
@@ -87,8 +90,11 @@ def main():
                         help="Ignore modified mkmks under this value")
     parser.add_argument('--kerns_thresh', type=int, default=0,
                         help="Ignore modified kerns under this value")
-    parser.add_argument('--glyphs_thresh', type=int, default=0,
+    parser.add_argument('--glyphs_thresh', type=float, default=0,
                         help="Ignore modified glyphs under this value")
+    parser.add_argument('-r', '--render_diffs', action='store_true',
+                        help=("Render glyphs with harfbuzz and compare "
+                              "pixel diffs."))
     args = parser.parse_args()
 
     font_a = InputFont(args.font_a)
@@ -112,6 +118,7 @@ def main():
         marks_threshold=args.marks_thresh,
         mkmks_threshold=args.mkmks_thresh,
         kerns_threshold=args.kerns_thresh,
+        render_diffs=args.render_diffs
     )
 
     report_formatter = CLIFormatter if not args.markdown else MDFormatter

--- a/Lib/diffenator/utils.py
+++ b/Lib/diffenator/utils.py
@@ -1,4 +1,10 @@
+import subprocess
+from PIL import Image
 from fontTools.varLib.mutator import instantiateVariableFont
+try:
+    from StringIO import StringIO
+except ImportError:  # py3 workaround
+    from io import BytesIO as StringIO
 
 __all__ = ['STYLE_TERMS', 'stylename_from_name',
            'vf_instance_from_static', 'vf_instance']
@@ -107,4 +113,26 @@ def vf_instance(vf_font, instance_name):
     loc = _axis_loc_from_name(vf_font, instance_name)
     instance = instantiateVariableFont(vf_font, loc, inplace=True)
     instance.is_variable = True
+    instance.axis_locations = loc
     return instance
+
+
+def render_string(font, string, features=None, pt_size=128):
+    """Use Harfbuzz to render a string"""
+
+    cmd = ['hb-view', '--font-size=%d' % pt_size]
+    if font.axis_locations:
+        location = ''
+        for axis, val in font.axis_locations.items():
+            location += '{}={}, '.format(axis, val)
+        cmd += ['--variations=%s' % location]
+    if features:
+        cmd += ['--features=%s' % features]
+    cmd += [font.path, u'{}'.format(string)]
+    try:
+        img = StringIO(subprocess.check_output(cmd))
+        return Image.open(img)
+    except FileNotFoundError:
+        raise OSError(
+            "hb-view was not found. Check if Harbuzz is installed."
+        )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.3.2',
+    version='0.4.2',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/diffenator",

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -8,8 +8,11 @@ from diffenator.diff import (
     diff_glyphs,
     diff_marks,
     diff_kerning,
+    diff_area,
+    _diff_images
 )
 import sys
+from PIL import Image
 if sys.version_info.major == 3:
     unicode = str
 
@@ -141,6 +144,73 @@ class TestGlyphs(unittest.TestCase):
         self.diff = diff_glyphs(font_a, font_b)
         missing = self.diff['missing']
         self.assertNotEqual(missing, [])
+
+    def test_area(self):
+        area_a = 100
+        area_b = 75
+        self.assertEqual(diff_area(area_a, area_b), 0.25)
+        self.assertEqual(diff_area(area_b, area_a), 0.25)
+
+    def test_render_diff_r01(self):
+        """Compare a crude F against a blank glyph.
+
+        Half the pixels have changed"""
+        img_a_px = [
+            255, 1, 1,   1,
+            255, 1, 255, 255,
+            255, 1, 1,   1,
+            255, 1, 255, 255,
+        ]
+        img_b_px = [
+            255, 255, 255, 255,
+            255, 255, 255, 255,
+            255, 255, 255, 255,
+            255, 255, 255, 255,
+        ]
+
+        img_a = Image.new('L', (4, 4))
+        img_a.putdata(img_a_px)
+        img_b = Image.new('L', (4, 4))
+        img_b.putdata(img_b_px)
+        self.assertEqual(_diff_images(img_a, img_b), 0.5)
+
+    def test_render_diff_r02(self):
+        """Glyphs are identical"""
+        img_a_px = [
+            255, 1, 1,   1,
+            255, 1, 255, 255,
+            255, 1, 1,   1,
+            255, 1, 255, 255,
+        ]
+        img_b_px = img_a_px
+        img_a = Image.new('L', (4, 4))
+        img_a.putdata(img_a_px)
+        img_b = Image.new('L', (4, 4))
+        img_b.putdata(img_b_px)
+        self.assertEqual(_diff_images(img_a, img_b), 0.0)
+
+    def test_render_diff_r03(self):
+        """Glyphs are offset.
+
+        TODO (M FOLEY) this should return a match.
+        The glyphs haven't changed, just the metrics"""
+        img_a_px = [
+            0  , 0  , 255, 255,
+            0  , 0  , 255, 255,
+            255, 255, 255, 255,
+            255, 255, 255, 255,
+        ]
+        img_b_px = [
+            255, 255, 255, 255,
+            255, 0  , 0, 255,
+            255, 0  , 0, 255,
+            255, 255, 255, 255,
+        ]
+        img_a = Image.new('L', (4, 4))
+        img_a.putdata(img_a_px)
+        img_b = Image.new('L', (4, 4))
+        img_b.putdata(img_b_px)
+        self.assertEqual(_diff_images(img_a, img_b), 0.375)
 
 
 class TestMarks(unittest.TestCase):


### PR DESCRIPTION
Uses Harfbuzz to render each glyph which are then compared by counting
pixel differences.

Implementation is based on
https://github.com/googlei18n/nototools/blob/master/nototools/shape_diff.py

Fixes #4

@davelab6 Still wip, keep this open.