### PR TITLE
Improve diff reports.

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -70,12 +70,15 @@ class Tbl:
         str
         """
         report = formatter()
-        report.subsubheading(self.table_name)
 
         if strings_only and self.renderable:
+            report.subsubheading(self.table_name)
             string = ' '.join([r['string'] for r in self._data[:limit]])
             report.paragraph(string)
         else:
+            report.subsubheading("{}: {}".format(
+                self.table_name, len(self._data)
+            ))
             report.table_heading(self._report_columns)
             for row in self._data[:limit]:
                 culled_row = []
@@ -310,7 +313,7 @@ class Formatter:
         self._text.append('')
 
     def paragraph(self, string):
-        self._text.append(string)
+        self._text.append("{}\n".format(string))
 
     @property
     def text(self):

--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 import sys
 if sys.version_info[0] < 3 and sys.version_info[1] < 6:
     raise ImportError("Visualize module requires Python3.6+!")

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -17,7 +17,7 @@ Module to diff fonts.
 from __future__ import print_function
 import collections
 from diffenator.utils import render_string
-from diffenator import DiffTable
+from diffenator import DiffTable, TXTFormatter, MDFormatter
 import functools
 import os
 import time
@@ -109,21 +109,27 @@ class DiffFonts:
 
     def _to_report(self, limit=50, dst=None, r_type="txt"):
         """Output before and after report"""
-        report = []
+        reports = []
+
+        report_header = TXTFormatter() if r_type == "txt" else MDFormatter()
+        report_header.heading("Diffenator")
+        report_header.paragraph(("Displaying the {} most significant items in "
+            "each table. To increase use the '-ol' flag").format(limit))
+        reports.append(report_header.text)
         for table in self._data:
             for subtable in self._data[table]:
                 current_table = self._data[table][subtable]
                 if len(current_table) < 1:
                     continue
                 if r_type == "txt":
-                    report.append(current_table.to_txt(limit=limit))
+                    reports.append(current_table.to_txt(limit=limit))
                 elif r_type == "md":
-                    report.append(current_table.to_md(limit=limit))
+                    reports.append(current_table.to_md(limit=limit))
         if dst:
             with open(dst, 'w') as doc:
-                doc.write("\n\n".join(report))
+                doc.write("\n\n".join(reports))
         else:
-            return "\n\n".join(report)
+            return "\n\n".join(reports)
 
     def to_txt(self, limit=50, dst=None):
         """Output diff report as txt"""

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.6.4',
+    version='0.6.5',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/diffenator",


### PR DESCRIPTION
- Display how many items have changed
- Include help message which tells users how to increase report item limits

---

**before**:

### names modified

id | string_a | string_b
--- | --- | --- | 
(5, 3, 1, 1033) | Version 2.000986; 2015; ttfautohint (v1.3) | Version 2.002; 2015; ttfautohint (v1.3)

### attribs modified

table | attrib | value_a | value_b
--- | --- | --- | --- | 
head | modified | 2015/05/21 18:38:03 | 2019/01/25 18:55:06
head | fontRevision | 2.00099 | 2.002
post | isFixedPitch | 0 | 1

---

**after**:
# Diffenator

Displaying the 200 most significant items in each table. To increase use the '-ol' flag


### names modified: 1

id | string_a | string_b
--- | --- | --- | 
(5, 3, 1, 1033) | Version 2.000986; 2015; ttfautohint (v1.3) | Version 2.002; 2015; ttfautohint (v1.3)

### attribs modified: 3

table | attrib | value_a | value_b
--- | --- | --- | --- | 
head | modified | 2015/05/21 18:38:03 | 2019/01/25 18:55:06
head | fontRevision | 2.00099 | 2.002
post | isFixedPitch | 0 | 1