### PR TITLE
Proposed update for font names in readme for increased clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Pair and class to class kerning are supported. The class kerns get flattened int
 
 Values by default are scaled in relation to the font's upm. This means we can easily compare fonts with differing upms. e.g
 
-font_a @1000upm
+font_after @1000upm
 
 - kern = pos A V -100;
 
 
-font_b @2000upm
+font_before @2000upm
 
 - kern = pos A V -200
 
@@ -75,11 +75,11 @@ $ pip install . # -e . for dev installation
 ## Usage:
 
 ```
-$ diffenator ./path/to/font_a.ttf ./path/to/font_b.ttf
+$ diffenator ./path/to/font_after.ttf ./path/to/font_before.ttf
 
 # Generate before and after gifs
 
-$ diffenator ./path/to/font_a.ttf ./path/to/font_b.ttf -r ./path/to/out_gifs
+$ diffenator ./path/to/font_after.ttf ./path/to/font_before.ttf -r ./path/to/out_gifs
 ```
 
 ## Python (Google fonts):
@@ -87,9 +87,9 @@ $ diffenator ./path/to/font_a.ttf ./path/to/font_b.ttf -r ./path/to/out_gifs
 ```
 >>> from diffenator import diff_fonts
 >>> from diffenator.font import InputFont
->>> font_a = InputFont('./path/to/font_a.ttf')
->>> font_b = InputFont('./path/to/font_b.ttf')
->>> diff_fonts(font_a, font_b)
+>>> font_after = InputFont('./path/to/font_after.ttf')
+>>> font_before = InputFont('./path/to/font_before.ttf')
+>>> diff_fonts(font_after, font_before)
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Pair and class to class kerning are supported. The class kerns get flattened int
 
 Values by default are scaled in relation to the font's upm. This means we can easily compare fonts with differing upms. e.g
 
-font_after @1000upm
+font_before @1000upm
 
 - kern = pos A V -100;
 
 
-font_before @2000upm
+font_after @2000upm
 
 - kern = pos A V -200
 
@@ -75,11 +75,11 @@ $ pip install . # -e . for dev installation
 ## Usage:
 
 ```
-$ diffenator ./path/to/font_after.ttf ./path/to/font_before.ttf
+$ diffenator ./path/to/font_before.ttf ./path/to/font_after.ttf
 
 # Generate before and after gifs
 
-$ diffenator ./path/to/font_after.ttf ./path/to/font_before.ttf -r ./path/to/out_gifs
+$ diffenator ./path/to/font_before.ttf ./path/to/font_after.ttf -r ./path/to/out_gifs
 ```
 
 ## Python (Google fonts):
@@ -87,9 +87,9 @@ $ diffenator ./path/to/font_after.ttf ./path/to/font_before.ttf -r ./path/to/out
 ```
 >>> from diffenator import diff_fonts
 >>> from diffenator.font import InputFont
->>> font_after = InputFont('./path/to/font_after.ttf')
 >>> font_before = InputFont('./path/to/font_before.ttf')
->>> diff_fonts(font_after, font_before)
+>>> font_after = InputFont('./path/to/font_after.ttf')
+>>> diff_fonts(font_before, font_after)
 ...
 ```
 


### PR DESCRIPTION
I keep forgetting what order to put arguments in, and have to check the gifs against sources to find an obvious change.

This is because the args this asks for are `font_a` and `font_b`, and there are two logical interpretations of this:
1. I want to compare a font _before_ & _after_, so surely `font_a` is "before" and `font_b` is "after"
2. "Before" starts with a "b" and "After" starts with an "a," so surely `font_a` is "after" and `font_b` is "before" (based on a test just now, this is the actual answer)

Is there some even-more obvious answer here, like requiring explicit flags (`--before` and `--after`), or might this doc update be enough to make things obvious for users?