### PR TITLE
Add DEBUG log level to rendered diffs

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -12,6 +12,7 @@ import uharfbuzz as hb
 import os
 import shutil
 import tempfile
+import logging
 try:
     from StringIO import StringIO
 except ImportError:  # py3 workaround
@@ -28,6 +29,10 @@ CHOICES = [
     'glyphs',
     'kerns'
 ]
+
+logger = logging.getLogger("fontdiffenator")
+logger.setLevel(logging.INFO)
+
 
 class Tbl:
 

--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.6"
+__version__ = "0.7.7"
 import sys
 if sys.version_info[0] < 3 and sys.version_info[1] < 6:
     raise ImportError("Visualize module requires Python3.6+!")

--- a/Lib/diffenator/__main__.py
+++ b/Lib/diffenator/__main__.py
@@ -41,6 +41,7 @@ Output images:
 diffenator /path/to/font_before.ttf /path/to/font_after.ttf -r /path/to/img_dir
 """
 from argparse import RawTextHelpFormatter
+import logging
 from diffenator import CHOICES, __version__
 from diffenator.font import DFont
 from diffenator.diff import DiffFonts
@@ -69,7 +70,8 @@ def main():
                         help="Output report as html.")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Output verbose reports')
-
+    parser.add_argument('-l', '--log-level', choices=('INFO', 'DEBUG', 'WARN'),
+                        default='INFO')
     parser.add_argument('-i', '--vf-instance', default='wght=400',
                         help='Set vf variations e.g "wght=400"')
 
@@ -89,6 +91,9 @@ def main():
     parser.add_argument('-r', '--render-path',
                         help="Path to generate before and after gifs to.")
     args = parser.parse_args()
+
+    logger = logging.getLogger("fontdiffenator")
+    logger.setLevel(args.log_level)
 
     diff_options = dict(
             marks_thresh=args.marks_thresh,

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -26,8 +26,8 @@ import logging
 __all__ = ['DiffFonts', 'diff_metrics', 'diff_kerning',
             'diff_marks', 'diff_mkmks', 'diff_attribs', 'diff_glyphs']
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger = logging.getLogger('fontdiffenator')
+
 
 def timer(method):
     def timed(*args, **kw):
@@ -348,6 +348,7 @@ def _modified_glyphs(glyphs_before, glyphs_after, thresh=0.00,
             font_before = glyphs_before[k]['glyph'].font
             font_after = glyphs_after[k]['glyph'].font
             glyph = glyphs_before[k]
+            logger.debug('Rendering {} {}'.format(glyph['glyph'].name, glyph['string']))
             diff = diff_rendering(font_before, font_after, glyph['string'], glyph['features'])
         else:
             # using abs does not take into consideration if a curve is reversed

--- a/Lib/diffenator/dump.py
+++ b/Lib/diffenator/dump.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 
 logging.basicConfig(level=logging.WARN)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('fontdiffenator')
 
 
 def dump_nametable(font):

--- a/Lib/diffenator/font.py
+++ b/Lib/diffenator/font.py
@@ -36,8 +36,7 @@ if sys.version_info.major == 3:
     unicode = str
 
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger = logging.getLogger('fontdiffenator')
 
 class DFont(TTFont):
     """Container font for ttfont, freetype and hb fonts"""

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.7.6',
+    version='0.7.7',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/diffenator",


### PR DESCRIPTION
Whilst rendering diffs for Barlow, hb-view hanged on the combination '--'. This PR allows users to set the logger to DEBUG mode. It will then print off every glyph which is being run through hb-view.
