### PR TITLE
Improve image cell tabulation

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.11"
+__version__ = "0.7.12"
 import sys
 if sys.version_info[0] < 3 and sys.version_info[1] < 6:
     raise ImportError("Visualize module requires Python3.6+!")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.7.11',
+    version='0.7.12',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/diffenator",


### PR DESCRIPTION
Tab width is now calculated by using the longest row's advance width. This should stop overflow issues when a row's advance width is greater than the tab value.

Cells per a row are now calculated by using the tab width / img_width.

Before:
![glyphs_modified](https://user-images.githubusercontent.com/7525512/55072407-efc2c380-5082-11e9-93de-8a6d9f9b1a8b.gif)


After:
![glyphs_modified](https://user-images.githubusercontent.com/7525512/55072428-fc471c00-5082-11e9-9e70-f069c6a63982.gif)

