### PR TITLE
Do not exit if hb-view raises an error

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.13"
+__version__ = "0.7.14"
 import sys
 if sys.version_info[0] < 3 and sys.version_info[1] < 6:
     raise ImportError("Visualize module requires Python3.6+!")

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -368,8 +368,18 @@ def _modified_glyphs(glyphs_before, glyphs_after, thresh=0.00,
 def diff_rendering(font_before, font_after, string, features):
     """Render a string for each font and return the different pixel count
     as a percentage"""
-    img_before = render_string(font_before, string, features)
-    img_after = render_string(font_after, string, features)
+    try:
+        img_before = render_string(font_before, string, features)
+        img_after = render_string(font_after, string, features)
+    except:
+        # hb-view on Linux will infrequently produce an out of memory error
+        # https://travis-ci.org/m4rc1e/fonts/builds/508961834. As a temp
+        # fix, we can add glyphs which trigger this error as a diff result.
+        # Ideally we will fix this in the future. I am not sure whether this
+        # error is part of harfbuzz or the memory consumption of this script
+        # (most probably the latter).
+        logger.info("hb-view: out of memory on string {}".format(string))
+        return 1.0
     return _diff_images(img_before, img_after)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fonttools==3.34.2
-freetype-py==2.0.0.post6
-Pillow==5.4.1
-pycairo==1.18.0
-uharfbuzz==0.3.0
+fonttools>=3.34.2
+freetype-py>=2.0.0.post6
+Pillow>=5.4.1
+pycairo>=1.18.0
+uharfbuzz>=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
     install_requires=[
         "fonttools>=3.34.2",
         "fonttools>=3.28.0",
-	"Pillow==5.4.1",
-        "pycairo==1.18.0",
-        "uharfbuzz==0.3.0",
-        "freetype-py==2.0.0.post6",
+	"Pillow>=5.4.1",
+        "pycairo>=1.18.0",
+        "uharfbuzz>=0.3.0",
+        "freetype-py>=2.0.0.post6",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.7.13',
+    version='0.7.14',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/diffenator",


### PR DESCRIPTION
This is a temp fix.

Due to the memory consumption of this tool, hb-view will infrequently raise an out of memory error (I've only had this happen on Ubuntu with machines that have less than 8gb of memory). If an out of memory error occurs, the glyph which caused it is appended to the diff so we can manually check it.

When I run memory_profiler, the tool does consume a boat load of memory. We are often diffing millions of objects against each other. I may spend sometime in the future refactoring/optimising the memory consumption. For now, it will have to do.