### PR TITLE
Fix KeyError traceback found in BeVietnam family

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.16"
+__version__ = "0.7.17"
 import sys
 if sys.version_info[0] < 3 and sys.version_info[1] < 6:
     raise ImportError("Visualize module requires Python3.6+!")

--- a/Lib/diffenator/dump.py
+++ b/Lib/diffenator/dump.py
@@ -602,9 +602,10 @@ class DumpAnchors:
         table = DFontTableIMG(self._font, name, renderable=True)
         for l_idx in range(len(anchors1)):
             for m_group in anchors1[l_idx]:
-
                 for anchor in anchors1[l_idx][m_group]:
                     if anc1_is_combining and not anchor['glyph'].combining:
+                        continue
+                    if m_group not in anchors2[l_idx]:
                         continue
                     for anchor2 in anchors2[l_idx][m_group]:
                         if anc2_is_combining and not anchor2['glyph'].combining:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.7.16',
+    version='0.7.17',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/diffenator",


### PR DESCRIPTION
When diffing https://github.com/bettergui/BeVietnam, it crashes when trying to dump the mark records. I've solved this issue by skipping mark combos if they only contain base glyphs.

The OT feature dumpers are a bit of a mess. I'm making fairly good progress on fontTools.otlLib.unbuild which should tidy up this code significantly.