### PR TITLE
Support otf

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 import sys
 if sys.version_info[0] < 3 and sys.version_info[1] < 6:
     raise ImportError("Visualize module requires Python3.6+!")

--- a/Lib/diffenator/dump.py
+++ b/Lib/diffenator/dump.py
@@ -250,14 +250,26 @@ def dump_glyph_metrics(font):
     """
     table = DFontTableIMG(font, "metrics", renderable=True)
 
+    glyphset = font.ttfont.getGlyphSet()
     for name, glyph in font.glyphset.items():
         adv = font.ttfont["hmtx"][name][0]
-        try:
-            lsb = font.ttfont["glyf"][name].xMin
-            rsb = adv - font.ttfont['glyf'][name].xMax
-        except AttributeError:
-            lsb = 0
-            rsb = 0
+        if "glyf" in font.ttfont.keys():
+            try:
+                lsb = font.ttfont["glyf"][name].xMin
+                rsb = adv - font.ttfont['glyf'][name].xMax
+            except AttributeError:
+                lsb = 0
+                rsb = 0
+        elif "CFF " in font.ttfont.keys():
+            try:
+                bounds = font.ttfont["CFF "].cff.values()[0].CharStrings[name].calcBounds(glyphset)
+                lsb = bounds[0]
+                rsb = adv - bounds[-2]
+            except TypeError:
+                lsb = 0
+                rsb = 0
+        else:
+            raise Exception("Only ttf and otf fonts are supported")
         table.append({'glyph': glyph,
                 'lsb': lsb, 'rsb': rsb, 'adv': adv,
                 'string': glyph.characters,

--- a/Lib/diffenator/font.py
+++ b/Lib/diffenator/font.py
@@ -151,7 +151,6 @@ class DFont(TTFont):
         self.glyphs = dump_glyphs(self)
         self.marks = anchors.marks_table
         self.mkmks = anchors.mkmks_table
-        self.glyph_metrics = dump_glyph_metrics(self)
         self.attribs = dump_attribs(self)
         self.names = dump_nametable(self)
         self.kerns = dump_kerning(self)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.8.0',
+    version='0.9.0',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/diffenator",


### PR DESCRIPTION
Diffenator and Dumper now support CFF fonts.

Luckily the only function which referenced the glyf table was dump_glyph_metrics.

I'm still not sure how well this will work on CFF variable fonts. We'll cross that bridge when we come to it.