### PR TITLE
Move vf instantiation into its own function

### DIFF
--- a/Lib/diffenator/__main__.py
+++ b/Lib/diffenator/__main__.py
@@ -43,7 +43,7 @@ diffenator /path/to/font_before.ttf /path/to/font_after.ttf -r /path/to/img_dir
 from argparse import RawTextHelpFormatter
 import logging
 from diffenator import CHOICES, __version__
-from diffenator.font import DFont
+from diffenator.font import DFont, font_matcher
 from diffenator.diff import DiffFonts
 import argparse
 
@@ -73,6 +73,7 @@ def main():
     parser.add_argument('-l', '--log-level', choices=('INFO', 'DEBUG', 'WARN'),
                         default='INFO')
     parser.add_argument('-i', '--vf-instance',
+                        default=None,
                         help='Set vf variations e.g "wght=400"')
 
     parser.add_argument('--marks_thresh', type=int, default=0,
@@ -106,18 +107,7 @@ def main():
     )
     font_before = DFont(args.font_before)
     font_after = DFont(args.font_after)
-
-    if font_before.is_variable and not font_after.is_variable:
-        font_before.set_variations_from_static(font_after)
-
-    elif not font_before.is_variable and font_after.is_variable:
-        font_after.set_variations_from_static(font_before)
-
-    elif font_before.is_variable and font_after.is_variable and args.vf_instance:
-        variations = {s.split('=')[0]: float(s.split('=')[1]) for s
-                      in args.vf_instance.split(", ")}
-        font_before.set_variations(variations)
-        font_after.set_variations(variations)
+    font_matcher(font_before, font_after, args.vf_instance)
 
     diff = DiffFonts(font_before, font_after, diff_options)
 

--- a/Lib/diffenator/font.py
+++ b/Lib/diffenator/font.py
@@ -108,6 +108,7 @@ class DFont(TTFont):
 
     def set_variations(self, axes):
         """Instantiate a ttfont VF with axes vals"""
+        logger.debug("Instantiating {} using {}".format(self, axes))
         if self.is_variable:
             font = instantiateVariableFont(self._src_ttfont, axes, inplace=False)
             self.ttfont = copy(font)
@@ -249,4 +250,21 @@ class Glyph:
 
     def __str__(self):
         return self.name
+
+
+def font_matcher(font_before, font_after, axes=None):
+    """Instantiate a variable font so it matches a static font. If two
+    variable fonts and an axes dict is provided, instantiate both
+    variable fonts using the axes dict."""
+    if font_before.is_variable and not font_after.is_variable:
+        font_before.set_variations_from_static(font_after)
+
+    elif not font_before.is_variable and font_after.is_variable:
+        font_after.set_variations_from_static(font_before)
+
+    elif font_before.is_variable and font_after.is_variable and axes:
+        variations = {s.split('=')[0]: float(s.split('=')[1]) for s
+                      in axes.split(", ")}
+        font_before.set_variations(variations)
+        font_after.set_variations(variations)
 


### PR DESCRIPTION
Since this logic was never included in a function, any tool/lib that wanted to use diffenator to diff vfs would have to roll their own vf to static matcher. Both gftools qa and @graphicore's dashboard have been affected by this. Now any tool can just import the `font_matcher` function instead.