### PR TITLE
set_variations_from_static: Improve instantiating Thin and ExtraLight instances

### DIFF
--- a/Lib/diffenator/font.py
+++ b/Lib/diffenator/font.py
@@ -141,6 +141,13 @@ class DFont(TTFont):
         variations = {}
         if self.is_variable:
             variations["wght"] = dfont.ttfont["OS/2"].usWeightClass
+            # Google Fonts used to set the usWeightClass of Thin static
+            # fonts to 250 and the ExtraLight to 275. Override these
+            # values with 100 and 200.
+            if variations["wght"] == 250:
+                variations["wght"] = 100
+            if variations["wght"] == 275:
+                variations["wght"] = 200
             variations["wdth"] = WIDTH_CLASS_TO_FVAR[dfont.ttfont["OS/2"].usWidthClass]
             # TODO (M Foley) add slnt axes
             self.set_variations(variations)


### PR DESCRIPTION
When diffing a static font against a VF, we have to instantiate the VF so it matches the static font. For the weight axis value, we use the static font's OS/2.usWeightClass. This works well for weights Light to Black. It doesn't work well for the Thin and ExtraLight because our VF spec differs to our legacy static font spec. For static fonts we used to set the Thin OS/2.usWeightClass to 250 and the ExtraLight to 275. For VFs we set the fvar values to 100 and 200. This PR will override these legacy usWeightClass values.