### PR TITLE
Add CBDT support

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,17 +1,15 @@
 __version__ = "0.9.1"
+
+import io
 import sys
 if sys.version_info[0] < 3 and sys.version_info[1] < 6:
     raise ImportError("Visualize module requires Python3.6+!")
 from array import array
 from PIL import Image
-from ctypes import cast, memmove, CDLL, c_void_p, c_int
-from sys import byteorder
 from cairo import Context, ImageSurface, FORMAT_A8, FORMAT_ARGB32
 from freetype.raw import *
 import uharfbuzz as hb
 import os
-import shutil
-import tempfile
 import logging
 try:
     from StringIO import StringIO
@@ -27,7 +25,8 @@ CHOICES = [
     'attribs',
     'metrics',
     'glyphs',
-    'kerns'
+    'kerns',
+    'cbdt'
 ]
 
 logger = logging.getLogger("fontdiffenator")
@@ -134,9 +133,9 @@ class Tbl:
         ----------
         font: DFont
         font_position: str
-            Label indicating which font has been used. 
+            Label indicating which font has been used.
         dst: str
-            Path to output image. If no path is given, return in-memory 
+            Path to output image. If no path is given, return in-memory
         """
         # TODO (M Foley) better packaging for pycairo, freetype-py
         # and uharfbuzz.
@@ -198,7 +197,7 @@ class Tbl:
             char_info = buf.glyph_infos
             char_pos = buf.glyph_positions
             for info, pos in zip(char_info, char_pos):
-                gid = info.codepoint            
+                gid = info.codepoint
                 font.ftfont.load_glyph(gid, flags=6)
                 bitmap = font.ftslot.bitmap
 
@@ -284,15 +283,39 @@ def _make_image_surface(bitmap, copy=True):
 
 
 class DiffTable(Tbl):
-
     def __init__(self, table_name, font_a, font_b,
                  data=None, renderable=False):
         super(DiffTable, self).__init__(table_name, data, renderable=renderable)
         self._font_a = font_a
         self._font_b = font_b
 
-    def to_gif(self, dst, padding_characters="", limit=800):
+    def to_cbdt_gif(self, dst):
+        font_a_images = read_cbdt(self._font_a.ttfont)
+        font_b_images = read_cbdt(self._font_b.ttfont)
 
+        for element in self._data:
+            key_before = element["glyph before"]
+            key_after = element["glyph after"]
+
+            image_1 = font_a_images[key_before]
+            image_1_gif = Image.new('RGBA', image_1.size, (255, 255, 255))
+            image_1_gif.paste(image_1, image_1)
+            image_1_gif = image_1_gif.convert('RGB').convert('P', palette=Image.ADAPTIVE)
+
+            image_2 = font_b_images[key_after]
+            image_2_gif = Image.new('RGBA', image_2.size, (255, 255, 255))
+            image_2_gif.paste(image_2, image_2)
+            image_2_gif = image_2_gif.convert('RGB').convert('P', palette=Image.ADAPTIVE)
+
+            img_path = os.path.join(dst, f"{key_before}.gif")
+            image_1_gif.save(img_path,
+                             save_all=True,
+                             append_images=[image_2_gif],
+                             duration=1000,
+                             loop=0
+            )
+
+    def to_gif(self, dst, padding_characters="", limit=800):
         tab_width = max(self._tab_width(self._font_a),
                         self._tab_width(self._font_b))
         img_a = self._to_png(self._font_a, "Before",
@@ -308,9 +331,10 @@ class DiffTable(Tbl):
             dst,
             save_all=True,
             append_images=[img_b],
-            loop=10000,
-            duration=1000
+            duration=1000,
+            loop=0
         )
+
 
 class DFontTable(Tbl):
 
@@ -480,4 +504,11 @@ class HTMLFormatter(Formatter):
     def img(self, path):
         self._text.append("<img src='%s'>" % path)
 
-
+def read_cbdt(ttfont):
+    cbdt_glyphs = {}
+    if ttfont.has_key("CBDT"):
+        cbdt = ttfont["CBDT"]
+        for strike_data in cbdt.strikeData:
+            for key, data in strike_data.items():
+                cbdt_glyphs[key] = Image.open(io.BytesIO(data.imageData)).convert("RGBA")
+    return cbdt_glyphs

--- a/Lib/diffenator/__main__.py
+++ b/Lib/diffenator/__main__.py
@@ -86,6 +86,8 @@ def main():
                         help="Ignore modified glyphs under this value")
     parser.add_argument('--metrics_thresh', type=int, default=0,
                         help="Ignore modified metrics under this value")
+    parser.add_argument('--cbdt_thresh', type=float, default=0,
+                        help="Ignore modified CBDT glyphs under this value")
     parser.add_argument('-rd', '--render_diffs', action='store_true',
                         help=("Render glyphs with hb-view and compare "
                               "pixel diffs."))
@@ -102,8 +104,11 @@ def main():
             kerns_thresh=args.kerns_thresh,
             glyphs_thresh=args.glyphs_thresh,
             metrics_thresh=args.metrics_thresh,
+            cbdt_thresh=args.cbdt_thresh,
             to_diff=args.to_diff,
-            render_diffs=args.render_diffs
+            render_diffs=args.render_diffs,
+            render_path=args.render_path,
+            html_output=args.html,
     )
     font_before = DFont(args.font_before)
     font_after = DFont(args.font_after)

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -436,30 +436,18 @@ def _diff_images(img_before, img_after):
     pixels.
 
     TODO (M FOLEY) Crop images so there are no sidebearings to glyphs"""
-    width_before, height_before = img_before.size
-    width_after, height_after = img_after.size
-    data_before = img_before.getdata()
-    data_after = img_after.getdata()
-
-    width, height = max(width_before, width_after), max(height_before, height_after)
-    offset_ax = (width - width_before) // 2
-    offset_ay = (height - height_before) // 2
-    offset_bx = (width - width_after) // 2
-    offset_by = (height - height_after) // 2
+    pixels1 = img_before.convert('L').getdata()
+    pixels2 = img_after.convert('L').getdata()
+    pixels = zip(pixels1, pixels2)
 
     diff = 0
-    for y in range(height):
-        for x in range(width):
-            ax, ay = x - offset_ax, y - offset_ay
-            bx, by = x - offset_bx, y - offset_by
-            if (ax < 0 or bx < 0 or ax >= width_before or bx >= width_after or
-                ay < 0 or by < 0 or ay >= height_before or by >= height_after):
-                diff += 1
-            else:
-                if data_before[ax + ay *width_before] != data_after[bx + by * width_after]:
-                    diff += 1
+    for px1, px2 in pixels:
+        if px1 is not px2:
+            diff += 1
+    pixel_count = 1.0 * img_before.size[0] * img_before.size[1]
+
     try:
-        return round(diff / float(width * height), 4)
+        return round(diff / pixel_count, 4)
     except ZeroDivisionError:
         return 0.0
 

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -17,11 +17,11 @@ Module to diff fonts.
 from __future__ import print_function
 import collections
 from diffenator import DiffTable, TXTFormatter, MDFormatter, HTMLFormatter
-import functools
 import os
 import time
 import logging
 from PIL import Image
+from . import read_cbdt
 
 
 __all__ = ['DiffFonts', 'diff_metrics', 'diff_kerning',
@@ -54,19 +54,23 @@ class DiffFonts:
     font_after: DFont
     settings: dict
     """
-    
+
     SETTINGS = dict(
         glyphs_thresh=0,
         marks_thresh=0,
         mkmks_thresh=0,
         metrics_thresh=0,
         kerns_thresh=0,
+        cbdt_thresh=0,
         to_diff=["*"],
         render_diffs=False,
+        render_path=False,
+        html_output=False
     )
     def __init__(self, font_before, font_after, settings=None):
         self.font_before = font_before
         self.font_after = font_after
+        self.renderable = font_after.ftfont.is_scalable and font_before.ftfont.is_scalable
         self._data = collections.defaultdict(dict)
         self._settings = self.SETTINGS
         if settings:
@@ -92,6 +96,8 @@ class DiffFonts:
                 self.marks(self._settings["marks_thresh"])
             if "mkmks" in self._settings["to_diff"]:
                 self.mkmks(self._settings["mkmks_thresh"])
+            if "cbdt" in self._settings["to_diff"]:
+                self.cbdt(self._settings["cbdt_thresh"])
 
     def run_all_diffs(self):
         self.names()
@@ -101,6 +107,7 @@ class DiffFonts:
         self.metrics(self._settings["metrics_thresh"])
         self.marks(self._settings["marks_thresh"])
         self.mkmks(self._settings["mkmks_thresh"])
+        self.cbdt(self._settings["cbdt_thresh"])
 
     def to_dict(self):
         serialised_data = self._serialise()
@@ -114,14 +121,17 @@ class DiffFonts:
         for table in self._data:
             for subtable in self._data[table]:
                 _table = self._data[table][subtable]
-                if not _table.renderable or len(_table) < 1:
+                if len(_table) < 1:
                     continue
-                filename = _table.table_name.replace(" ", "_") + ".gif"
-                img_path = os.path.join(dst, filename)
-                if table == "metrics":
-                    _table.to_gif(img_path, padding_characters="II", limit=limit)
-                else:
-                    _table.to_gif(img_path, limit=limit)
+                if table == "cbdt":
+                    _table.to_cbdt_gif(dst)
+                elif _table.renderable and self.renderable:
+                    filename = _table.table_name.replace(" ", "_") + ".gif"
+                    img_path = os.path.join(dst, filename)
+                    if table == "metrics":
+                        _table.to_gif(img_path, padding_characters="II", limit=limit)
+                    else:
+                        _table.to_gif(img_path, limit=limit)
 
     def _to_report(self, limit=50, dst=None, r_type="txt", image_dir=None):
         """Output before and after report"""
@@ -149,7 +159,7 @@ class DiffFonts:
                 elif r_type == "md":
                     reports.append(current_table.to_md(limit=limit))
                 elif r_type == "html":
-                    if image_dir and current_table.renderable:
+                    if image_dir and self.renderable and current_table.renderable:
                         image = os.path.join(image_dir, "%s_%s.gif" % (table, subtable))
                         reports.append(current_table.to_html(limit=limit,
                                        image=image))
@@ -197,6 +207,18 @@ class DiffFonts:
             self.font_before.mkmks, self.font_after.mkmks,
             name="mkmks",
             thresh=threshold
+        )
+
+    def cbdt(self, threshold=None, render_path=None, html_output=None):
+        if not threshold:
+            threshold = self._settings["cbdt_thresh"]
+        if not render_path:
+            render_path = self._settings["render_path"]
+        if not html_output:
+            html_output = self._settings["html_output"]
+        self._data["cbdt"] = diff_cbdt_glyphs(
+            self.font_before, self.font_after,
+            thresh=threshold, render_path=render_path, html_output=html_output
         )
 
     def metrics(self, threshold=None):
@@ -505,7 +527,7 @@ def diff_kerning(font_before, font_after, thresh=2, scale_upms=True):
     return {
         'new': new,
         'missing': missing,
-        'modified': modified, 
+        'modified': modified,
     }
 
 
@@ -569,7 +591,7 @@ def diff_metrics(font_before, font_after, thresh=1, scale_upms=True):
     modified.report_columns(["glyph", "diff_adv"])
     modified.sort(key=lambda k: k["diff_adv"], reverse=True)
     return {
-            'modified': modified 
+            'modified': modified
             }
 
 
@@ -774,3 +796,37 @@ def _modified_marks(marks_before, marks_after, thresh=4,
             table.append(mark)
     return table
 
+
+@timer
+def diff_cbdt_glyphs(font_before, font_after, thresh=4, render_path=None, html_output=False):
+    cbdt_before = read_cbdt(font_before.ttfont)
+    cbdt_after = read_cbdt(font_after.ttfont)
+
+    chars_before = {r["string"]: str(r["glyph"]) for r in font_before.glyphs}
+    chars_after = {r["string"]: str(r["glyph"]) for r in font_after.glyphs}
+
+    modified = []
+    for char in set(chars_before) & set(chars_after):
+        glyph_name_before = chars_before[char]
+        glyph_name_after = chars_after[char]
+        if glyph_name_before in cbdt_before and glyph_name_after in cbdt_after:
+            diff = _diff_images(cbdt_before[glyph_name_before], cbdt_after[glyph_name_after])
+            if diff > thresh:
+                modified.append({
+                    "glyph before": glyph_name_before,
+                    "glyph after": glyph_name_after,
+                    "string": char,
+                    "diff": diff,
+                    "image": f"<img src='{render_path}/{glyph_name_before}.gif'>",
+                })
+
+    modified = DiffTable("cbdt glyphs modified", font_before, font_after, data=modified, renderable=True)
+    if render_path and html_output:
+        modified.report_columns(["glyph before", "glyph after", "diff", "string", "image"])
+    else:
+        modified.report_columns(["glyph before", "glyph after", "diff", "string"])
+    modified.sort(key=lambda k: abs(k["diff"]), reverse=True)
+
+    return {
+        "modified": modified
+    }


### PR DESCRIPTION
This PR will add support for CBDT fonts. It will produce a `diff` value in the same way as for vector fonts.

When using HTML output, an animated before/after GIF will be added per modified glyph:

![image](https://user-images.githubusercontent.com/4570664/82202618-77f8cd80-9902-11ea-8851-c8aeddb8723f.png)

The diff routine is optimised in speed and LOC, as comparing CBDT glyphs took a lot of time. This is the only change that also touches vector font diffs, but it produces the exact same diff value.