### PR TITLE
Use static font nameID2 or 17 to set variations

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 import io
 import sys

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -382,7 +382,6 @@ def _modified_glyphs(glyphs_before, glyphs_after, thresh=0.00,
             glyph_after['area'] = (glyph_after['area'] / upm_after) * upm_before
 
         if render_diffs:
-            logger.debug('Rendering {}'.format(k))
             diff = diff_rendering(glyph_before['glyph'], glyph_after['glyph'])
         else:
             # using abs does not take into consideration if a curve is reversed

--- a/Lib/diffenator/font.py
+++ b/Lib/diffenator/font.py
@@ -149,7 +149,7 @@ class DFont(TTFont):
 
     def set_variations(self, axes):
         """Instantiate a ttfont VF with axes vals"""
-        logger.debug("Instantiating {} using {}".format(self, axes))
+        logger.debug("Setting variations to {}".format(axes))
         if self.is_variable:
             font = instantiateVariableFont(self._src_ttfont, axes, inplace=False)
             self.ttfont = copy(font)
@@ -201,12 +201,17 @@ class DFont(TTFont):
             subfamilyname = f"{family_name_width} {subfamilyname}"
 
         if subfamilyname in self.instances_coordinates:
+            logger.debug(f"Instance name '{subfamilyname}' matches static font "
+                "subfamily names. Setting variations using this instance.")
             variations = self.instances_coordinates[subfamilyname]
             self.set_variations(variations)
             return
 
         # if the font doesn't contain an instance name which matches the
         # static font, infer the correct values
+        logger.debug(f"Font does not contain an instance name which matches "
+            f"static font subfamily names '{subfamilyname}'. Inferring "
+            "values instead.")
         variations = {}
         # wght
         parsed_weight = find_token(
@@ -242,11 +247,7 @@ class DFont(TTFont):
             width_class = static_font.ttfont["OS/2"].usWidthClass
             variations["wdth"] = WIDTH_CLASS_TO_FVAR[width_class]
         # TODO (M Foley) add slnt axes
-
-        # slnt/ital
-
-
-            self.set_variations(variations)
+        self.set_variations(variations)
 
     def recalc_tables(self):
         """Recalculate DFont tables"""

--- a/Lib/diffenator/font.py
+++ b/Lib/diffenator/font.py
@@ -120,9 +120,12 @@ class DFont(TTFont):
             self.recalc_tables()
 
     def _get_instances_coordinates(self):
+        results = {}
         if self.is_variable:
-            return [i.coordinates for i in self._src_ttfont["fvar"].instances]
-        return None
+            for inst in self._src_ttfont['fvar'].instances:
+                inst_name = self._src_ttfont['name'].getName(inst.subfamilyNameID, 3, 1, 1033).toUnicode()
+                results[inst_name] = inst.coordinates
+        return results
 
     def _get_dflt_instance_coordinates(self):
         if self.is_variable:
@@ -173,47 +176,76 @@ class DFont(TTFont):
         else:
             logger.info("Not vf")
 
-    def set_variations_from_static(self, dfont):
-        """Set the variation of a variable font using a static font.
-        The static font's filename will be used first to determine coordinates.
-        If values cannot be parsed from the filename, use values in the static
-        font's OS/2 table."""
-        variations = {}
-        if self.is_variable:
-            # wght
-            parsed_weight = find_token(
-                os.path.basename(dfont.path),
-                list(WEIGHT_NAME_TO_FVAR.keys())
-            )
-            if parsed_weight:
-                variations["wght"] = WEIGHT_NAME_TO_FVAR[parsed_weight]
-            else:
-                logger.debug(f"Couldn't parse weight value from {dfont.path}")
-                weight_class = dfont.ttfont["OS/2"].usWeightClass
-                # Google Fonts used to set the usWeightClass of Thin static
-                # fonts to 250 and the ExtraLight to 275. Override these
-                # values with 100 and 200.
-                if weight_class == 250:
-                    weight_class = 100
-                if weight_class == 275:
-                    weight_class = 200
-                variations["wght"] = weight_class
+    def set_variations_from_static(self, static_font):
+        """Set VF font variations so they match a static font."""
+        if not self.is_variable:
+            raise Exception("Not a variable font")
 
-            # wdth
-            # We cannot simply use OS/2.usWidthClass since Google Fonts
-            # releases Condensed styles as new families.These new families
-            # have a usWidthClass of 5 (Normal).
-            parsed_width = find_token(
-                os.path.basename(dfont.path),
-                list(WIDTH_NAME_TO_FVAR.keys())
-            )
-            if parsed_width:
-                variations["wdth"] = WIDTH_NAME_TO_FVAR[parsed_width]
-            else:
-                logger.debug(f"Couldn't parse weight value from {dfont.path}")
-                width_class = dfont.ttfont["OS/2"].usWidthClass
-                variations["wdth"] = WIDTH_CLASS_TO_FVAR[width_class]
-            # TODO (M Foley) add slnt axes
+        # Use an fvar instance if its name matches the static font's
+        # typographic subfamily name or subfamily name
+        subfamilyname = static_font.ttfont['name'].getName(2, 3, 1, 1033)
+        typosubfamilyname = static_font.ttfont['name'].getName(17, 3, 1, 1033)
+
+        subfamilyname = typosubfamilyname.toUnicode() if typosubfamilyname else \
+            subfamilyname.toUnicode()
+
+        # The Google Fonts v1 api can only handle the wght axis. For families
+        # which have widths, we have to release them as a seperate family,
+        # https://fonts.google.com/?query=condensed
+        # To distinguish the width family from the normal family, we append
+        # the width to the family name e.g Roboto Condensed
+        filename = os.path.basename(static_font.path)
+        family_name = filename.split("-")[0]
+        family_name_width = find_token(family_name, list(WIDTH_NAME_TO_FVAR.keys()))
+        if family_name_width:
+            subfamilyname = f"{family_name_width} {subfamilyname}"
+
+        if subfamilyname in self.instances_coordinates:
+            variations = self.instances_coordinates[subfamilyname]
+            self.set_variations(variations)
+            return
+
+        # if the font doesn't contain an instance name which matches the
+        # static font, infer the correct values
+        variations = {}
+        # wght
+        parsed_weight = find_token(
+            os.path.basename(static_font.path),
+            list(WEIGHT_NAME_TO_FVAR.keys())
+        )
+        if parsed_weight:
+            variations["wght"] = WEIGHT_NAME_TO_FVAR[parsed_weight]
+        else:
+            logger.debug(f"Couldn't parse weight value from {dfont.path}")
+            weight_class = static_font.ttfont["OS/2"].usWeightClass
+            # Google Fonts used to set the usWeightClass of Thin static
+            # fonts to 250 and the ExtraLight to 275. Override these
+            # values with 100 and 200.
+            if weight_class == 250:
+                weight_class = 100
+            if weight_class == 275:
+                weight_class = 200
+            variations["wght"] = weight_class
+
+        # wdth
+        # We cannot simply use OS/2.usWidthClass since Google Fonts
+        # releases Condensed styles as new families. These new families
+        # have a usWidthClass of 5 (Normal).
+        parsed_width = find_token(
+            os.path.basename(static_font.path),
+            list(WIDTH_NAME_TO_FVAR.keys())
+        )
+        if parsed_width:
+            variations["wdth"] = WIDTH_NAME_TO_FVAR[parsed_width]
+        else:
+            logger.debug(f"Couldn't parse weight value from {dfont.path}")
+            width_class = static_font.ttfont["OS/2"].usWidthClass
+            variations["wdth"] = WIDTH_CLASS_TO_FVAR[width_class]
+        # TODO (M Foley) add slnt axes
+
+        # slnt/ital
+
+
             self.set_variations(variations)
 
     def recalc_tables(self):

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ $ diffenator ./path/to/font_before.ttf ./path/to/font_after.ttf -r ./path/to/out
 ## Python (Google fonts):
 
 ```
->>> from diffenator import diff_fonts
->>> from diffenator.font import InputFont
->>> font_before = InputFont('./path/to/font_before.ttf')
->>> font_after = InputFont('./path/to/font_after.ttf')
->>> diff_fonts(font_before, font_after)
+>>> from diffenator import DiffFonts
+>>> from diffenator.font import DFont
+>>> font_before = DFont('./path/to/font_before.ttf')
+>>> font_after = DFont('./path/to/font_after.ttf')
+>>> diff = DiffFonts(font_before, font_after)
 ...
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils import log
 
 setup(
     name='fontdiffenator',
-    version='0.9.4',
+    version='0.9.5',
     author="Google Fonts Project Authors",
     description="Font regression tester for Google Fonts",
     url="https://github.com/googlefonts/fontdiffenator",


### PR DESCRIPTION
Currently, the function `DFont.set_variations_from_static` attempts to infer the correct instance values by using the static font's filename or its OS/2 values. A better approach is to check whether the VF contains an instance which has the same name as the static font's typographic subfamily name or subfamilyname. If it does, just use this instance, if it doesnt, infer the values.