### PR TITLE
Workflow improvements

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -353,6 +353,12 @@ class DFontTableIMG(DFontTable):
 class Formatter:
     """Base Class for formatters"""
 
+    def start_document(self):
+        pass
+
+    def close_document(self):
+        pass
+
     def __init__(self):
         self._text = []
 
@@ -447,29 +453,49 @@ class MDFormatter(Formatter):
 class HTMLFormatter(Formatter):
     """Formatter for HTML"""
 
-    def style(self):
+    def start_document(self):
         self._text.append(
             """
-            <style>
-            html{font-family: sans-serif; padding: 10px;}
+<!DOCTYPE html>
+<html>
+<head>
+<meta property="text/html; charset=utf-8" http-equiv="Content-Type">
+</head>
+<body>
+"""
+        )
 
-            table{
-              font-family: arial, sans-serif;
-              border-collapse: collapse;
-              width: 100%;
-            }
-
-            td, th {
-              border: 1px solid #dddddd;
-              text-align: left;
-              padding: 8px;
-            }
-
-            tr:nth-child(even) {
-              background-color: #dddddd;
-              }
-            </style>
+    def close_document(self):
+        self._text.append(
             """
+</body>
+</html>
+"""
+        )
+
+    def style(self):
+        self._text.append(
+"""
+<style>
+html{font-family: sans-serif; padding: 10px;}
+
+table{
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #dddddd;
+  }
+</style>
+"""
         )
     def heading(self, string):
         self._text.append("<h1>{}</h1>\n".format(string))

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -320,6 +320,19 @@ def _modified_names(names_before, names_after):
     return table
 
 
+def _add_glyph_descriptions(glyphs):
+    """Add unicode name for uniXXXX glyphs for better understanding"""
+    for glyph in glyphs:
+        glyph['description'] = ''
+        _glyph_name = glyph['glyph'].name
+        if _glyph_name.startswith('uni'):
+            _hex_unicode = _glyph_name[3:]
+            try:
+                glyph['description'] = unicodedata.name(chr(int(_hex_unicode, 16)))
+            except:
+                pass
+    return glyphs
+
 @timer
 def diff_glyphs(font_before, font_after,
                 thresh=0.00, scale_upms=True, render_diffs=False):
@@ -357,21 +370,21 @@ def diff_glyphs(font_before, font_after,
     glyphs_before_h = {r['glyph'].key: r for r in glyphs_before}
     glyphs_after_h = {r['glyph'].key: r for r in glyphs_after}
 
-    missing = _subtract_items(glyphs_before_h, glyphs_after_h)
-    new = _subtract_items(glyphs_after_h, glyphs_before_h)
-    modified = _modified_glyphs(glyphs_before_h, glyphs_after_h, thresh,
-                                scale_upms=scale_upms, render_diffs=render_diffs)
+    missing = _add_glyph_descriptions(_subtract_items(glyphs_before_h, glyphs_after_h))
+    new = _add_glyph_descriptions(_subtract_items(glyphs_after_h, glyphs_before_h))
+    modified = _add_glyph_descriptions(_modified_glyphs(glyphs_before_h, glyphs_after_h, thresh,
+                                scale_upms=scale_upms, render_diffs=render_diffs))
     
     new = DiffTable("glyphs new", font_before, font_after, data=new, renderable=True)
-    new.report_columns(["glyph", "area", "string"])
+    new.report_columns(["glyph", "description", "area", "string"])
     new.sort(key=lambda k: k["glyph"].name)
 
     missing = DiffTable("glyphs missing", font_before, font_after, data=missing, renderable=True)
-    missing.report_columns(["glyph", "area", "string"])
+    missing.report_columns(["glyph", "description", "area", "string"])
     missing.sort(key=lambda k: k["glyph"].name)
 
     modified = DiffTable("glyphs modified", font_before, font_after, data=modified, renderable=True)
-    modified.report_columns(["glyph", "diff", "string"])
+    modified.report_columns(["glyph", "description", "diff", "string"])
     modified.sort(key=lambda k: abs(k["diff"]), reverse=True)
     return {
         'new': new,

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -21,6 +21,7 @@ import os
 import time
 import logging
 from PIL import Image
+import unicodedata
 
 
 __all__ = ['DiffFonts', 'diff_metrics', 'diff_kerning',
@@ -143,6 +144,7 @@ class DiffFonts:
         elif r_type == "html":
             report_header = HTMLFormatter()
 
+        report_header.start_document()
         report_header.style()
         report_header.heading("Diffenator")
         report_header.paragraph(("Displaying the {} most significant items in "
@@ -164,6 +166,16 @@ class DiffFonts:
                                        image=image))
                     else:
                         reports.append(current_table.to_html(limit=limit))
+
+        # Create empty formatters again, just to extract close_document()
+        if r_type == "txt":
+            report_header = TXTFormatter()
+        elif r_type == "md":
+            report_header = MDFormatter()
+        elif r_type == "html":
+            report_header = HTMLFormatter()
+        report_header.close_document()
+        reports.append(report_header.text)
 
         if dst:
             with open(dst, 'w') as doc:


### PR DESCRIPTION
Adding unicode names to a "description" column for glyph diffs to quicker understand their nature without having to look up the unicode.
Also, the html report gets output with correct html structure now with encoding settings in an attempt to display the sample strings correctly. Unfortunately, in Safari (which I use), it still doesn't work. They show correctly in Chrome and I'm note sure whether they've done that before my changes.

Note: Of the two commits of this PR, the "import unicodedata" line is in the wrong commit.