### PR TITLE
Beginnings of a low-level table data diff

### DIFF
--- a/Lib/diffenator/__init__.py
+++ b/Lib/diffenator/__init__.py
@@ -29,6 +29,7 @@ CHOICES = [
     'kerns',
     'gdef_base',
     'gdef_mark',
+    'structural'
 ]
 
 logger = logging.getLogger("fontdiffenator")

--- a/Lib/diffenator/diff.py
+++ b/Lib/diffenator/diff.py
@@ -17,6 +17,7 @@ Module to diff fonts.
 from __future__ import print_function
 import collections
 from diffenator import DiffTable, TXTFormatter, MDFormatter, HTMLFormatter, read_cbdt
+from .structural import structural_diff
 import os
 import time
 import logging
@@ -101,6 +102,8 @@ class DiffFonts:
                 self.gdef_base()
             if "gdef_mark" in self._settings["to_diff"]:
                 self.gdef_mark()
+            if "structural" in self._settings["to_diff"]:
+                self.structural()
 
     def run_all_diffs(self):
         self.names()
@@ -113,6 +116,8 @@ class DiffFonts:
         self.cbdt(self._settings["cbdt_thresh"])
         self.gdef_base()
         self.gdef_mark()
+        # Don't run a structural diff unless specifically asked for
+        # self.structural()
 
     def to_dict(self):
         serialised_data = self._serialise()
@@ -265,6 +270,8 @@ class DiffFonts:
     def gdef_mark(self):
         self._data["gdef_mark"] = diff_gdef_mark(self.font_before, self.font_after)
 
+    def structural(self):
+        self._data["structural"] = structural_diff(self.font_before, self.font_after)
 
 def _subtract_items(items_a, items_b):
     subtract = set(items_a.keys()) - set(items_b.keys())

--- a/Lib/diffenator/structural.py
+++ b/Lib/diffenator/structural.py
@@ -1,0 +1,194 @@
+from diffenator import DiffTable
+from fontTools.misc.fixedTools import floatToFixedToStr
+from fontTools.misc.timeTools import timestampToString
+
+
+def structural_diff(left, right):
+    lefttables = set(left.ttfont.keys())
+    righttables = set(right.ttfont.keys())
+    results = {}
+
+    directory = DiffTable("OpenType Table Directory", left, right)
+    directory.report_columns(["table", "before", "after"])
+    for t in sorted(list(lefttables & righttables)):
+        if not (t in left.ttfont and t in right.ttfont):
+            directory.append(
+                {
+                    "table": t,
+                    "before": ("X" if t in left.ttfont else ""),
+                    "after": ("X" if t in right.ttfont else ""),
+                }
+            )
+        diffclass = "Diff_%s" % t.replace("/", "_")  # OS/2. :-(
+        if diffclass in globals():
+            differ = globals()[diffclass]
+            diff = differ(left, right, t).diff()
+            if diff:
+                results[t] = diff
+    results["directory"] = directory
+    return results
+
+
+def _format_panose(panose):
+    return ",".join(
+        {"%s=%i" % (k[1:], getattr(panose, k)) for k in sorted(panose.__dict__.keys())}
+    )
+
+
+def bitfield(n):
+    return lambda x: ("{0:0" + str(n) + "b}").format(x)
+
+
+class OTTableDiffer:
+    fields = []
+    skip_fields = []
+    use_dict_for_fields = True
+    field_formatters = {
+        "fontRevision": lambda x: floatToFixedToStr(x, 16),
+        "tableVersion": lambda x: floatToFixedToStr(x, 16),
+        "created": timestampToString,
+        "flags": bitfield(16),
+        "panose": _format_panose,
+        "macStyle": bitfield(16),
+        "ulUnicodeRange1": bitfield(32),
+        "ulUnicodeRange2": bitfield(32),
+        "ulUnicodeRange3": bitfield(32),
+        "ulUnicodeRange4": bitfield(32),
+    }
+
+    def __init__(self, left, right, tablename):
+        self.left = left
+        self.right = right
+        self.tablename = tablename
+
+    def prepdiff(self):
+        self.diffreport = DiffTable("%s table" % self.tablename, self.left, self.right)
+        self.diffreport.report_columns(["field", "before", "after"])
+        self.lefttable = self.left.ttfont[self.tablename]
+        self.righttable = self.right.ttfont[self.tablename]
+
+    def diff(self):
+        self.prepdiff()
+        fields = self.fields
+        if self.use_dict_for_fields:
+            fields = set(self.lefttable.__dict__.keys()) & set(
+                self.righttable.__dict__.keys()
+            )
+
+        for field in fields:
+            if field in self.skip_fields:
+                continue
+            if not (hasattr(self.lefttable, field) and hasattr(self.righttable, field)):
+                continue
+            leftattr = getattr(self.lefttable, field)
+            rightattr = getattr(self.righttable, field)
+            if field in self.field_formatters:
+                leftattr = self.field_formatters[field](leftattr)
+                rightattr = self.field_formatters[field](rightattr)
+            if leftattr != rightattr:
+                self.diffreport.append(
+                    {"field": field, "before": leftattr, "after": rightattr}
+                )
+        return self.diffreport
+
+
+class Diff_head(OTTableDiffer):
+    skip_fields = [
+        "checkSumAdjustment",
+        "magicNumber",
+        "modified",
+    ]
+
+
+class Diff_hhea(OTTableDiffer):
+    pass
+
+
+class Diff_maxp(OTTableDiffer):
+    pass
+
+
+class Diff_OS_2(OTTableDiffer):
+    pass
+
+
+class Diff_post(OTTableDiffer):
+    pass
+
+
+class Diff_vhea(OTTableDiffer):
+    pass
+
+
+class Diff_fvar(OTTableDiffer):
+    def diff(self):
+        self.prepdiff()
+        axes_left = {axis.axisTag: axis for axis in self.lefttable.axes}
+        axes_right = {axis.axisTag: axis for axis in self.righttable.axes}
+        alltags = set(axes_left.keys()) & set(axes_right.keys())
+        for tag in alltags:
+            if not (tag in axes_left and tag in axes_right):
+                self.diffreport.append(
+                    {
+                        "field": tag + " axis",
+                        "before": ("X" if tag in axes_left else ""),
+                        "after": ("X" if tag in axes_right else ""),
+                    }
+                )
+                continue
+            axis_left = self._format_axis(axes_left[tag])
+            axis_right = self._format_axis(axes_right[tag])
+            for key in axis_left.keys():
+                if axis_left[key] != axis_right[key]:
+                    self.diffreport.append(
+                        {
+                            "field": key,
+                            "before": axis_left[key],
+                            "after": axis_right[key],
+                        }
+                    )
+        return self.diffreport
+
+    def _format_axis(self, axis):
+        tag = axis.axisTag
+        return {
+            tag + " flags": "0x%X" % axis.flags,
+            tag + " MinValue": floatToFixedToStr(axis.minValue, 16),
+            tag + " DefaultValue": floatToFixedToStr(axis.defaultValue, 16),
+            tag + " MaxValue": floatToFixedToStr(axis.maxValue, 16),
+            tag + " AxisNameID": str(axis.axisNameID),
+        }
+
+
+class Diff_avar(OTTableDiffer):
+    def diff(self):
+        if "fvar" not in self.left.ttfont or "fvar" not in self.right.ttfont:
+            return
+        self.prepdiff()
+
+        self.diffreport.report_columns(["axis", "before", "after"])
+
+        axisTagsleft = [axis.axisTag for axis in self.left.ttfont["fvar"].axes]
+        axisTagsright = [axis.axisTag for axis in self.right.ttfont["fvar"].axes]
+
+        def _seg_to_str(segtuple):
+            k, v = segtuple
+            return "%s => %s" % (floatToFixedToStr(k, 14), floatToFixedToStr(v, 14))
+
+        for tag in set(axisTagsright) & set(axisTagsleft):
+            lsegs = list(self.lefttable.segments.get(tag, {}).items())
+            rsegs = list(self.righttable.segments.get(tag, {}).items())
+            if len(lsegs) != len(rsegs):
+                self.diffreport.append(
+                    {
+                        "axis": tag,
+                        "before": "%i segments" % len(lsegs),
+                        "after": "%i segments" % len(rsegs),
+                    }
+                )
+            for i in range(max(len(lsegs), len(rsegs)) + 1):
+                lseg = _seg_to_str(lsegs[i]) if i < len(lsegs) else "No mapping"
+                rseg = _seg_to_str(rsegs[i]) if i < len(rsegs) else "No mapping"
+                if lseg != rseg:
+                    self.diffreport.append({"axis": tag, "before": lseg, "after": rseg})
+        return self.diffreport


### PR DESCRIPTION
fontdiffenator is deliberately aimed at the semantic level - what are the user-facing differences between two font files? However, it's also a good basis for asking structural questions: how does the data in these two fonts differ? This adds a "structural" test which reports on differences within the OpenType tables. It isn't on by default, but can be asked for with `--td structural`. I plan to extend it to cover all the tables in the OT spec.

Here's some sample output:

```
****fvar table: 2****

field               before              after
wdth DefaultValu... 100.0               80.0
wght MinValue       1.0                 12.0

****avar table: 11****

axis                before              after
wdth                5 segments          0 segments
wdth                -1.0 => -1.0        No mapping
wdth                -0.5 => -0.61426... No mapping
wdth                -0.26 => -0.1571... No mapping
wdth                0.0 => 0.0          No mapping
wdth                1.0 => 1.0          No mapping
wght                11 segments         10 segments
wght                0.1667 => 0.1053... 0.1667 => 0.12
wght                0.6667 => 0.5684... 0.8333 => 0.7895...
wght                0.8333 => 0.7895... 1.0 => 1.0
wght                1.0 => 1.0          No mapping
```

```
****OS/2 table: 24****

field               before              after
ySuperscriptYSiz... 600                 1331
yStrikeoutSize      50                  102
sTypoDescender      -220                -555
version             4                   3
yStrikeoutPositi... 290                 512
usLastCharIndex     64260               65533
fsSelection         192                 64
usWinAscent         1052                2146
sxHeight            484                 1082
sTypoAscender       937                 2146
ulUnicodeRange2     0000000000000000... 0101000000000000...
ulUnicodeRange1     0010000000000000... 1110000000000000...
panose              SerifStyle=0,Let... SerifStyle=0,Let...
xAvgCharWidth       562                 1162
usWinDescent        224                 555
ySubscriptYSize     600                 1331
ySuperscriptXSiz... 650                 1434
ySubscriptYOffse... 75                  287
achVendID           PLAY                GOOG
usDefaultChar       0                   32
ySubscriptXSize     650                 1434
ySuperscriptYOff... 350                 977
ulUnicodeRange3     0000000000000000... 0000000000000000...
sCapHeight          649                 1456

****head table: 9****

field               before              after
created             Wed Mar  1 09:58... Fri Sep 12 12:29...
fontRevision        2.101               2.14
yMax                1035                2163
xMin                -524                -1825
xMax                1259                4188
lowestRecPPEM       7                   9
yMin                -220                -555
flags               0000000000000111... 0000000000011001...
unitsPerEm          1000                2048
```