### PR TITLE
use chr instead of fonttools.misc.unichr

### DIFF
--- a/Lib/diffenator/font.py
+++ b/Lib/diffenator/font.py
@@ -1,5 +1,4 @@
 """Module for DFont"""
-from fontTools.misc.py23 import unichr
 from fontTools.ttLib import TTFont, newTable
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.varLib.mutator import instantiateVariableFont
@@ -319,8 +318,8 @@ class InputGenerator(HbInputGenerator):
 
         # see if this glyph has a simple unicode mapping
         if name in self.reverse_cmap:
-            text = unichr(self.reverse_cmap[name])
-            if text != unichr(0):
+            text = chr(self.reverse_cmap[name])
+            if text != chr(0):
                 inputs.append(((), text))
 
         # check the substitution features

--- a/Lib/diffenator/hbinput.py
+++ b/Lib/diffenator/hbinput.py
@@ -16,7 +16,6 @@ TODO (M Foley) Remove this module
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import division, print_function
-from fontTools.misc import unichr
 from fontTools.ttLib import TTFont
 
 
@@ -96,7 +95,7 @@ class HbInputGenerator(object):
 
         # see if this glyph has a simple unicode mapping
         if name in self.reverse_cmap:
-            text = unichr(self.reverse_cmap[name])
+            text = chr(self.reverse_cmap[name])
             inputs.append(((), text))
 
         # check the substitution features


### PR DESCRIPTION
FontTools recently tidied up the misc module, https://github.com/fonttools/fonttools/pull/2243 which is causing the following fail: https://github.com/google/fonts/pull/3275/checks?check_run_id=2245344070

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.8/x64/bin/gftools-qa.py", line 48, in <module>
    from diffenator.font import DFont
  File "/opt/hostedtoolcache/Python/3.8.8/x64/lib/python3.8/site-packages/diffenator/font.py", line 6, in <module>
    from diffenator.hbinput import HbInputGenerator
  File "/opt/hostedtoolcache/Python/3.8.8/x64/lib/python3.8/site-packages/diffenator/hbinput.py", line 19, in <module>
    from fontTools.misc import unichr
ImportError: cannot import name 'unichr' from 'fontTools.misc' (/opt/hostedtoolcache/Python/3.8.8/x64/lib/python3.8/site-packages/fontTools/misc/__init__.py)
Error: Process completed with exit code 1.
```

Since this tool is now py3 only, there's no point using the fontTool's unichr function since py3's chr builtin function works just fine.
